### PR TITLE
Switchy Proxy Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ kotlin.incremental=true
 kotlin.code.style=official
 
 group=de.olivermakesco
-version=1.1.0
+version=1.2.0
 archives_base_name=switchykit

--- a/src/main/kotlin/Serde.kt
+++ b/src/main/kotlin/Serde.kt
@@ -1,7 +1,6 @@
 package de.olivermakesco.switchykit
 
 import dev.proxyfox.pluralkt.types.PkColor
-import dev.proxyfox.pluralkt.types.PkProxyTag
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -45,7 +44,13 @@ data class MinimalMemberJson(
     @SerialName("display_name") val displayName: String?,
     val pronouns: String?,
     val color: PkColor?,
-    @SerialName("proxy_tags") val proxyTags: ArrayList<PkProxyTag>
+    @SerialName("proxy_tags") val proxyTags: List<MinimalProxyTag>
+)
+
+@Serializable
+data class MinimalProxyTag(
+    val prefix: String?,
+    val suffix: String?
 )
 
 val json = Json {

--- a/src/main/kotlin/Serde.kt
+++ b/src/main/kotlin/Serde.kt
@@ -1,6 +1,7 @@
 package de.olivermakesco.switchykit
 
 import dev.proxyfox.pluralkt.types.PkColor
+import dev.proxyfox.pluralkt.types.PkProxyTag
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -43,7 +44,8 @@ data class MinimalMemberJson(
     val name: String,
     @SerialName("display_name") val displayName: String?,
     val pronouns: String?,
-    val color: PkColor?
+    val color: PkColor?,
+    @SerialName("proxy_tags") val proxyTags: ArrayList<PkProxyTag>
 )
 
 val json = Json {

--- a/src/main/kotlin/SwitchyKit.kt
+++ b/src/main/kotlin/SwitchyKit.kt
@@ -1,5 +1,6 @@
 package de.olivermakesco.switchykit
 
+import de.olivermakesco.switchykit.compat.addTagsModule
 import de.olivermakesco.switchykit.platform.PK
 import de.olivermakesco.switchykit.platform.TUL
 import folk.sisby.switchy.api.SwitchyApi
@@ -49,6 +50,7 @@ fun import(system: MinimalSystemJson, oldPresets: SwitchyPresets, player: Server
     val modules = mutableListOf<Identifier>()
     if (oldPresets.modules["switchy"*"drogtor"] == true) modules += "switchy"*"drogtor"
     if (oldPresets.modules["switchy"*"styled_nicknames"] == true) modules += "switchy"*"styled_nicknames"
+    if (oldPresets.modules["switchy_proxy"*"proxies"] == true) modules += "switchy_proxy"*"proxies"
 
     for (member in system.members) {
         val name = member.name.filter {
@@ -75,6 +77,10 @@ fun import(system: MinimalSystemJson, oldPresets: SwitchyPresets, player: Server
                 nick = "<color:$hex>$nick</color>"
             styled.styled_nickname = nick
             preset.putModule("switchy"*"styled_nicknames", styled)
+        }
+
+        if (oldPresets.modules["switchy_proxy"*"proxies"] == true) {
+            addTagsModule(preset, member.proxyTags)
         }
 
         updatedPresets[name] = preset

--- a/src/main/kotlin/compat/SwitchyProxyCompat.kt
+++ b/src/main/kotlin/compat/SwitchyProxyCompat.kt
@@ -1,12 +1,12 @@
 package de.olivermakesco.switchykit.compat
 
+import de.olivermakesco.switchykit.MinimalProxyTag
 import de.olivermakesco.switchykit.times
-import dev.proxyfox.pluralkt.types.PkProxyTag
 import folk.sisby.switchy.api.presets.SwitchyPreset
 import folk.sisby.switchy_proxy.ProxyTag
 import folk.sisby.switchy_proxy.modules.ProxyModule
 
-fun addTagsModule(preset: SwitchyPreset, tags: ArrayList<PkProxyTag>) {
+fun addTagsModule(preset: SwitchyPreset, tags: List<MinimalProxyTag>) {
     if (tags.isNotEmpty()) {
         val proxy = ProxyModule()
         tags.forEach { proxy.addTag(ProxyTag(it.prefix ?: "", it.suffix ?: "")) }

--- a/src/main/kotlin/compat/SwitchyProxyCompat.kt
+++ b/src/main/kotlin/compat/SwitchyProxyCompat.kt
@@ -1,0 +1,15 @@
+package de.olivermakesco.switchykit.compat
+
+import de.olivermakesco.switchykit.times
+import dev.proxyfox.pluralkt.types.PkProxyTag
+import folk.sisby.switchy.api.presets.SwitchyPreset
+import folk.sisby.switchy_proxy.ProxyTag
+import folk.sisby.switchy_proxy.modules.ProxyModule
+
+fun addTagsModule(preset: SwitchyPreset, tags: ArrayList<PkProxyTag>) {
+    if (tags.isNotEmpty()) {
+        val proxy = ProxyModule()
+        tags.forEach { proxy.addTag(ProxyTag(it.prefix ?: "", it.suffix ?: "")) }
+        preset.putModule("switchy_proxy"*"proxies", proxy)
+    }
+}

--- a/src/main/kotlin/platform/PK.kt
+++ b/src/main/kotlin/platform/PK.kt
@@ -54,16 +54,12 @@ object PK {
                 }
                 required(greedyString("link")) {
                     execute {
-                        try {
-                            val oldPresets = switchyPlayer.presets
-                            reply("commands.switchykit.pk.import.wait")
-                            val link = getArgument("link", String::class.java)
-                            val json: MinimalSystemJson = json.decodeFromString(URL(link).readText())
-                            logger.."Importing system for ${player.name} (${player.uuidAsString} from PK Export - $link"
-                            import(json, oldPresets, player, "pk import $link")
-                        } catch (e: Exception) {
-                            logger..e
-                        }
+                        val oldPresets = switchyPlayer.presets
+                        reply("commands.switchykit.pk.import.wait")
+                        val link = getArgument("link", String::class.java)
+                        val json: MinimalSystemJson = json.decodeFromString(URL(link).readText())
+                        logger.."Importing system for ${player.name} (${player.uuidAsString} from PK Export - $link"
+                        import(json, oldPresets, player, "pk import $link")
                     }
                 }
             }

--- a/src/main/kotlin/platform/PK.kt
+++ b/src/main/kotlin/platform/PK.kt
@@ -46,7 +46,7 @@ object PK {
                         }
                         val membersJson = arrayListOf<MinimalMemberJson>()
                         members.forEach {
-                            membersJson += MinimalMemberJson(it.name, it.displayName, it.pronouns, it.color, it.proxyTags)
+                            membersJson += MinimalMemberJson(it.name, it.displayName, it.pronouns, it.color, it.proxyTags.map { tag -> MinimalProxyTag(tag.prefix, tag.suffix) }.toList())
                         }
                         logger.."Importing system for ${player.name} (${player.uuidAsString} from PK API - ${system.id}"
                         import(MinimalSystemJson(system.tag, membersJson.toTypedArray()), oldPresets, player, "pk import")

--- a/src/main/kotlin/platform/PK.kt
+++ b/src/main/kotlin/platform/PK.kt
@@ -46,7 +46,7 @@ object PK {
                         }
                         val membersJson = arrayListOf<MinimalMemberJson>()
                         members.forEach {
-                            membersJson += MinimalMemberJson(it.name, it.displayName, it.pronouns, it.color)
+                            membersJson += MinimalMemberJson(it.name, it.displayName, it.pronouns, it.color, it.proxyTags)
                         }
                         logger.."Importing system for ${player.name} (${player.uuidAsString} from PK API - ${system.id}"
                         import(MinimalSystemJson(system.tag, membersJson.toTypedArray()), oldPresets, player, "pk import")
@@ -54,12 +54,16 @@ object PK {
                 }
                 required(greedyString("link")) {
                     execute {
-                        val oldPresets = switchyPlayer.presets
-                        reply("commands.switchykit.pk.import.wait")
-                        val link = getArgument("link", String::class.java)
-                        val json: MinimalSystemJson = json.decodeFromString(URL(link).readText())
-                        logger.."Importing system for ${player.name} (${player.uuidAsString} from PK Export - $link"
-                        import(json, oldPresets, player, "pk import $link")
+                        try {
+                            val oldPresets = switchyPlayer.presets
+                            reply("commands.switchykit.pk.import.wait")
+                            val link = getArgument("link", String::class.java)
+                            val json: MinimalSystemJson = json.decodeFromString(URL(link).readText())
+                            logger.."Importing system for ${player.name} (${player.uuidAsString} from PK Export - $link"
+                            import(json, oldPresets, player, "pk import $link")
+                        } catch (e: Exception) {
+                            logger..e
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/platform/TUL.kt
+++ b/src/main/kotlin/platform/TUL.kt
@@ -28,7 +28,8 @@ object TUL {
                                 tupper.name,
                                 tupper.nick,
                                 null,
-                                null
+                                null,
+                                arrayListOf()
                             ))
                         }
                         logger.."Importing system for ${player.name} (${player.uuidAsString} from Tul Export - $link"

--- a/src/main/kotlin/platform/TUL.kt
+++ b/src/main/kotlin/platform/TUL.kt
@@ -29,7 +29,7 @@ object TUL {
                                 tupper.nick,
                                 null,
                                 null,
-                                arrayListOf()
+                                if (!tupper.brackets.isNullOrEmpty()) arrayListOf(MinimalProxyTag(tupper.brackets[0], tupper.brackets[1])) else arrayListOf()
                             ))
                         }
                         logger.."Importing system for ${player.name} (${player.uuidAsString} from Tul Export - $link"
@@ -60,5 +60,5 @@ object TUL {
     }
 
     @Serializable
-    data class MinimalTupperJson(val name: String, val nick: String?, val tag: String?)
+    data class MinimalTupperJson(val name: String, val nick: String?, val tag: String?, val brackets: ArrayList<String>?)
 }

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -43,6 +43,11 @@
 			{
 				"id": "switchy-compat",
 				"versions": ">=2.0.0-"
+			},
+			{
+				"id": "switchy-proxy",
+				"versions": ">=1.1.8",
+				"optional": true
 			}
 		]
 	},


### PR DESCRIPTION
closes #5 

When [Switchy Proxy](https://modrinth.com/mod/switchy-proxy) is installed, importing from PK from token or json will populate presets with `proxies` modules, allowing for proxied messages.